### PR TITLE
Move RFC7942 to an informative reference.

### DIFF
--- a/draft-cel-nfsv4-rpc-over-quicv1.md
+++ b/draft-cel-nfsv4-rpc-over-quicv1.md
@@ -32,13 +32,13 @@ normative:
   RFC1833:
   RFC5531:
   RFC5665:
-  RFC7942:
   RFC9000:
   RFC9001:
 
 informative:
   RFC0768:
   RFC0793:
+  RFC7942:
   RFC8881:
 
 --- abstract


### PR DESCRIPTION
The way it's referred to in the text doesn't seem to require a normative
reference.