### PR TITLE
Tag BCP14 terms.

### DIFF
--- a/draft-cel-nfsv4-rpc-over-quicv1.md
+++ b/draft-cel-nfsv4-rpc-over-quicv1.md
@@ -96,7 +96,7 @@ RPC-over-RDMA.
 
 # Requirements Language
 
-{::boilerplate bcp14}
+{::boilerplate bcp14-tagged}
 
 # RPC-over-QUIC Framework
 


### PR DESCRIPTION
This restores the \<bcp14\> tags you had in the XML version.